### PR TITLE
Node.js 12 actions are deprecated

### DIFF
--- a/.github/workflows/app_test.yml
+++ b/.github/workflows/app_test.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '16'
           cache: 'npm'
       - name: npm install
         run: npm install

--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ inputs:
     description: 'redmine apikey to use'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
fix warning in pipelines `Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: genomenon/redmine-integration-action@bi-directional-pattern. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.`