### PR TITLE
Node.js 12 actions are deprecated

### DIFF
--- a/.github/workflows/app_test.yml
+++ b/.github/workflows/app_test.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '16'
           cache: 'npm'
       - name: npm install
         run: npm install

--- a/helper.test.js
+++ b/helper.test.js
@@ -57,9 +57,9 @@ describe('build_message', () => {
         "action": "opened"
       }
     };
-    const actual = await sut.build_message(prdata, context);
+    const actual = await sut.build_redmine_message(prdata, context);
 
-    expect(actual).toEqual("pull request [my pull request title](https://github.com/thaim/redmine-integration-action/pull/456) opened");
+    expect(actual).toEqual("Github Pull Request [my pull request title](https://github.com/thaim/redmine-integration-action/pull/456) opened");
   });
 
 
@@ -73,8 +73,8 @@ describe('build_message', () => {
         "action": "opened"
       }
     };
-    const actual = await sut.build_message(prdata, context);
+    const actual = await sut.build_redmine_message(prdata, context);
 
-    expect(actual).toEqual("pull request [it's my pull request title](https://github.com/thaim/redmine-integration-action/pull/456) opened");
+    expect(actual).toEqual("Github Pull Request [it's my pull request title](https://github.com/thaim/redmine-integration-action/pull/456) opened");
   });
 });


### PR DESCRIPTION
fix warning in pipelines `Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: genomenon/redmine-integration-action@bi-directional-pattern. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.`